### PR TITLE
Ft admin reject accept order 162179078

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,5 +1,5 @@
 [run]
-branch = False
+branch = True
 source = ./app
 
 [report]

--- a/app/api/v2/__init__.py
+++ b/app/api/v2/__init__.py
@@ -21,3 +21,7 @@ api.add_resource(UsersNotifications,
                  '/users/<id>/notifications', strict_slashes=False)
 api.add_resource(Notification,
                  '/notifications/<id>', strict_slashes=False)
+api.add_resource(AcceptOrder, '/parcels/<id>/accept', strict_slashes=False)
+api.add_resource(RejectOrder, '/parcels/<id>/reject', strict_slashes=False)
+
+

--- a/app/api/v2/utils/validators.py
+++ b/app/api/v2/utils/validators.py
@@ -93,6 +93,8 @@ class Validator:
             return 'Unsuccesful, order already delivered'
         if status == 'Canceled':
             return 'Unsuccessful, order is canceled'
+        if status == 'Rejected':
+            return 'Unsuccessful, order is rejected'
         return True
 
     def validate_order_data(self, order):

--- a/app/api/v2/views/order_views.py
+++ b/app/api/v2/views/order_views.py
@@ -117,6 +117,78 @@ class CancelOrder(Resource):
         return message_dict, status_code
 
 
+class AcceptOrder(Resource):
+    """Handle the route /parcels/<id>/deliver"""
+
+    def __init__(self):
+        self.orders = Orders()
+        self.validators = Validator()
+
+    @authenticate
+    def put(self, id, user_data):
+        """Handle put requests to route /parcels/<id>/deliver"""
+        message_dict = {}
+        status_code = 200
+        if not user_data['is_admin']:
+            return {message: 'You are not authorized to perform this operation'}, 403
+        try:
+            int_id = int(id)
+        except ValueError:
+            return {message: 'Wrong id format'}, 400
+
+        order = self.orders.get_order(int_id)
+
+        if order:
+            status = order['status']
+            error_message = self.validators.status_validator(status)
+            if error_message == True:
+                self.orders.change_order_status(
+                    order_id=int_id, status=in_transit)
+                order_d = self.orders.get_order(int_id)
+                message_dict = {message: 'Order accepted', 'order': order_d}
+            else:
+                return {message: error_message}, 400
+        else:
+            message_dict = {message: 'No Parcel delivery order with that id'}
+            status_code = 404
+        return message_dict, status_code
+
+class RejectOrder(Resource):
+    """Handle the route /parcels/<id>/deliver"""
+
+    def __init__(self):
+        self.orders = Orders()
+        self.validators = Validator()
+
+    @authenticate
+    def put(self, id, user_data):
+        """Handle put requests to route /parcels/<id>/deliver"""
+        message_dict = {}
+        status_code = 200
+        if not user_data['is_admin']:
+            return {message: 'You are not authorized to perform this operation'}, 403
+        try:
+            int_id = int(id)
+        except ValueError:
+            return {message: 'Wrong id format'}, 400
+
+        order = self.orders.get_order(int_id)
+
+        if order:
+            status = order['status']
+            error_message = self.validators.status_validator(status)
+            if error_message == True:
+                self.orders.change_order_status(
+                    order_id=int_id, status=rejected)
+                order_d = self.orders.get_order(int_id)
+                message_dict = {message: 'Order rejected', 'order': order_d}
+            else:
+                return {message: error_message}, 400
+        else:
+            message_dict = {message: 'No Parcel delivery order with that id'}
+            status_code = 404
+        return message_dict, status_code
+
 class DeliverOrder(Resource):
     """Handle the route /parcels/<id>/deliver"""
 

--- a/app/db_config.py
+++ b/app/db_config.py
@@ -82,7 +82,7 @@ def create_queries():
         current_location VARCHAR (50),
         dest VARCHAR (50) NOT NULL,
         weight INTEGER NOT NULL,
-        status VARCHAR (12) DEFAULT 'In-transit',
+        status VARCHAR (12) DEFAULT 'Pending',
         created_on TIMESTAMP DEFAULT NOW()
         );"""
 


### PR DESCRIPTION
**What does this PR do?**
Add accept and reject order endpoints

**Description of Task to be completed?**
- Add tests for accept and reject orders tests
- Add accept and reject order endpoints
 


**How should this be manually tested?**
- run ```python run.py```
- login as admin through ```/api/v2/auth/login```
 Use postman to try:
- PUT ```/api/v2/parcels/<parcel-id>/accept```` 
- - PUT ```/api/v2/parcels/<parcel-id>/reject```` 


**What are the relevant pivotal tracker stories?**
https://www.pivotaltracker.com/story/show/162179078
